### PR TITLE
fix(oidc): use one token endpoint auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open **`https://<YOUR_IP>:7443`** — on first launch you'll be prompted to crea
 | `PORT` | `7443` | HTTPS port |
 | `TLS_CERT_PATH` / `TLS_KEY_PATH` | *(auto)* | Custom TLS certificate & key paths |
 | `DATA_DIR` | `/app/data` | Database, certs, recordings, and logs |
+| `OIDC_TOKEN_AUTH_METHOD` | `client_secret_basic` | OIDC token endpoint client auth. Use `client_secret_basic` (or `basic`) or `client_secret_post` (or `post`). |
 
 > ⚠️ If no encryption key env var is set, Gatwy auto-generates one at `/app/data/encryption.key` with a warning banner. Fine for home-lab — not recommended for production.
 

--- a/packages/client/src/components/settings/AuthProvidersSettings.tsx
+++ b/packages/client/src/components/settings/AuthProvidersSettings.tsx
@@ -24,6 +24,7 @@ interface AuthSettings {
   'auth.oidc_admin_group_claim': string;
   'auth.oidc_admin_group_value': string;
   'auth.oidc_button_label': string;
+  'auth.oidc_token_auth_method': string;
 }
 
 const DEFAULTS: AuthSettings = {
@@ -48,6 +49,7 @@ const DEFAULTS: AuthSettings = {
   'auth.oidc_admin_group_claim': '',
   'auth.oidc_admin_group_value': '',
   'auth.oidc_button_label': 'Sign in with SSO',
+  'auth.oidc_token_auth_method': 'client_secret_basic',
 };
 
 export function AuthProvidersSettings() {
@@ -294,6 +296,16 @@ export function AuthProvidersSettings() {
               </Field>
               <Field label="Scope" hint="Space-separated OIDC scopes">
                 <input className="w-full px-3 py-2 bg-surface border border-border rounded text-text-primary focus:outline-none focus:ring-2 focus:ring-accent text-sm" value={settings['auth.oidc_scope']} onChange={(e) => set('auth.oidc_scope', e.target.value)} placeholder="openid email profile" />
+              </Field>
+              <Field label="Token Endpoint Auth Method" hint="Must match your identity provider. Env OIDC_TOKEN_AUTH_METHOD overrides this.">
+                <select
+                  className="w-full px-3 py-2 bg-surface border border-border rounded text-text-primary focus:outline-none focus:ring-2 focus:ring-accent text-sm"
+                  value={settings['auth.oidc_token_auth_method'] || 'client_secret_basic'}
+                  onChange={(e) => set('auth.oidc_token_auth_method', e.target.value)}
+                >
+                  <option value="client_secret_basic">client_secret_basic (HTTP Basic)</option>
+                  <option value="client_secret_post">client_secret_post (form body)</option>
+                </select>
               </Field>
             </div>
 

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -718,6 +718,14 @@ function runMigrations() {
         try { database.run('ALTER TABLE users ADD COLUMN mfa_method TEXT'); } catch { /* already exists */ }
       },
     },
+    {
+      version: 17,
+      run: (database: Database) => {
+        // OIDC token endpoint auth method
+        database.run(`INSERT OR IGNORE INTO settings (key, value) VALUES
+          ('auth.oidc_token_auth_method', 'client_secret_basic')`);
+      },
+    },
   ];
 
   for (const migration of migrations) {

--- a/packages/server/src/services/oidc.ts
+++ b/packages/server/src/services/oidc.ts
@@ -29,6 +29,22 @@ interface OidcConfig {
   scope: string;
 }
 
+type TokenAuthMethod = 'client_secret_basic' | 'client_secret_post';
+
+// Env OIDC_TOKEN_AUTH_METHOD overrides the UI setting. Accepts basic|post|client_secret_*.
+function resolveTokenAuthMethod(): TokenAuthMethod {
+  const raw = (
+    process.env.OIDC_TOKEN_AUTH_METHOD ||
+    getSetting('auth.oidc_token_auth_method') ||
+    'client_secret_basic'
+  )
+    .trim()
+    .toLowerCase();
+
+  if (raw === 'client_secret_post' || raw === 'post') return 'client_secret_post';
+  return 'client_secret_basic';
+}
+
 function getOidcConfig(): OidcConfig | null {
   const providerUrl = getSetting('auth.oidc_provider_url');
   const clientId = getSetting('auth.oidc_client_id');
@@ -115,19 +131,28 @@ export async function handleOidcCallback(
   let accessToken: string;
   let idTokenClaims: Record<string, unknown>;
   try {
+    const tokenAuth = resolveTokenAuthMethod();
+    const tokenBody = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: cfg.redirectUri,
+    });
+    const tokenHeaders: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+
+    if (tokenAuth === 'client_secret_post') {
+      tokenBody.set('client_id', cfg.clientId);
+      tokenBody.set('client_secret', cfg.clientSecret);
+    } else {
+      tokenHeaders.Authorization =
+        'Basic ' + Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64');
+    }
+
     const tokenRes = await fetch(tokenEndpoint, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Authorization: 'Basic ' + Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64'),
-      },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        redirect_uri: cfg.redirectUri,
-        client_id: cfg.clientId,
-        client_secret: cfg.clientSecret,
-      }).toString(),
+      headers: tokenHeaders,
+      body: tokenBody.toString(),
     });
 
     if (!tokenRes.ok) {

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -53,6 +53,7 @@ const DEFAULTS: Record<string, string> = {
   'auth.oidc_admin_group_claim': '',
   'auth.oidc_admin_group_value': '',
   'auth.oidc_button_label': 'Sign in with SSO',
+  'auth.oidc_token_auth_method': 'client_secret_basic',
   'auto_backup.enabled': 'false',
   'auto_backup.destination_mode': 'saved',
   'auto_backup.connection_id': '',


### PR DESCRIPTION
Send either client_secret_basic or client_secret_post, not both. Default is client_secret_basic. Set OIDC_TOKEN_AUTH_METHOD=post (or client_secret_post) when the IdP requires form-body auth. Also exposed as auth.oidc_token_auth_method in settings.