### PR TITLE
feat(vnc): optional remote display scale when the mouse does not line up 

### DIFF
--- a/packages/client/src/components/ConnectionModal.tsx
+++ b/packages/client/src/components/ConnectionModal.tsx
@@ -41,21 +41,15 @@ interface ConnectionModalProps {
 interface TunnelDef { id: string; localPort: string; remoteHost: string; remotePort: string; }
 
 /** Common remote desktop scaling (Windows / macOS / GNOME / KDE). */
-const VNC_DESKTOP_SCALES = [100, 125, 150, 165, 175, 200, 225, 250, 300] as const;
+const VNC_DESKTOP_SCALES = [100, 125, 150, 175, 200, 225, 250, 300] as const;
 
-function nearestVncDesktopScale(factor: number): string {
-  if (!Number.isFinite(factor) || factor <= 0 || factor === 1) return '100';
-  const pct = 100 / factor;
-  let best: (typeof VNC_DESKTOP_SCALES)[number] = 100;
-  let bestDist = Infinity;
-  for (const option of VNC_DESKTOP_SCALES) {
-    const dist = Math.abs(option - pct);
-    if (dist < bestDist) {
-      best = option;
-      bestDist = dist;
-    }
-  }
-  return String(best);
+function percentFromPointerScale(factor: number): number {
+  if (!Number.isFinite(factor) || factor <= 0 || factor === 1) return 100;
+  return Math.round(100 / factor);
+}
+
+function choiceForVncPercent(percent: number): string {
+  return (VNC_DESKTOP_SCALES as readonly number[]).includes(percent) ? String(percent) : 'custom';
 }
 
 const defaultPorts: Record<string, number> = {
@@ -216,7 +210,8 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
   const [tunnels, setTunnels] = useState<TunnelDef[]>(prefill?.tunnels ?? []);
   const [smbShare, setSmbShare] = useState(prefill?.smbShare ?? '');
   const [smbDomain, setSmbDomain] = useState(prefill?.smbDomain ?? '');
-  const [vncDesktopScale, setVncDesktopScale] = useState(prefill?.vncDesktopScale ?? '100');
+  const [vncScaleChoice, setVncScaleChoice] = useState(() => choiceForVncPercent(parseInt(prefill?.vncDesktopScale ?? '100', 10) || 100));
+  const [vncCustomScale, setVncCustomScale] = useState(prefill?.vncDesktopScale ?? '165');
   // DB-specific fields
   const [dbDatabase, setDbDatabase] = useState('');
   const [dbSslMode, setDbSslMode] = useState<'disable' | 'require' | 'verify-ca' | 'verify-full'>('disable');
@@ -258,7 +253,9 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         if (d.skipCertValidation !== undefined) setSkipCertValidation(!!d.skipCertValidation);
         if (d.extraConfig?.promptOnConnect) setPromptOnConnect(true);
         {
-          setVncDesktopScale(nearestVncDesktopScale(Number(d.extraConfig?.pointerScaleX ?? 1)));
+          const pct = percentFromPointerScale(Number(d.extraConfig?.pointerScaleX ?? 1));
+          setVncScaleChoice(choiceForVncPercent(pct));
+          setVncCustomScale(String(pct === 100 ? 165 : pct));
         }
         if (d.shares && Array.isArray(d.shares)) {
           setSelectedShareRoles(d.shares.filter((s: { shareType: string }) => s.shareType === 'role').map((s: { targetId: string }) => s.targetId));
@@ -345,7 +342,14 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         body.extraConfig = dbCfg;
       }
       if (protocol === 'vnc') {
-        const pct = parseInt(vncDesktopScale, 10) || 100;
+        const pct = vncScaleChoice === 'custom'
+          ? Number(vncCustomScale)
+          : parseInt(vncScaleChoice, 10) || 100;
+        if (!Number.isFinite(pct) || pct < 50 || pct > 400) {
+          setError('Remote display scale must be between 50% and 400%');
+          setSaving(false);
+          return;
+        }
         if (pct === 100) {
           body.extraConfig = null;
         } else {
@@ -735,17 +739,34 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
           {protocol === 'vnc' && (
             <div>
               <label className="block text-xs font-medium text-text-secondary mb-1">Remote display scale</label>
-              <select
-                value={vncDesktopScale}
-                onChange={(e) => setVncDesktopScale(e.target.value)}
-                className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent"
-              >
-                {VNC_DESKTOP_SCALES.map((pct) => (
-                  <option key={pct} value={String(pct)}>
-                    {pct === 100 ? '100% (default)' : `${pct}%`}
-                  </option>
-                ))}
-              </select>
+              <div className="flex gap-2">
+                <select
+                  value={vncScaleChoice}
+                  onChange={(e) => setVncScaleChoice(e.target.value)}
+                  className={`${vncScaleChoice === 'custom' ? 'w-1/2' : 'w-full'} px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent`}
+                >
+                  {VNC_DESKTOP_SCALES.map((pct) => (
+                    <option key={pct} value={String(pct)}>
+                      {pct === 100 ? '100% (default)' : `${pct}%`}
+                    </option>
+                  ))}
+                  <option value="custom">Custom</option>
+                </select>
+                {vncScaleChoice === 'custom' && (
+                  <div className="relative w-1/2">
+                    <input
+                      type="number"
+                      min={50}
+                      max={400}
+                      step={1}
+                      value={vncCustomScale}
+                      onChange={(e) => setVncCustomScale(e.target.value)}
+                      className="w-full px-2.5 py-1.5 pr-7 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent"
+                    />
+                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-text-secondary">%</span>
+                  </div>
+                )}
+              </div>
               <p className="text-[11px] text-text-secondary mt-1 leading-tight">
                 Match the scaling set on the remote desktop. Use this if the mouse is not lined up with what you see.
               </p>

--- a/packages/client/src/components/ConnectionModal.tsx
+++ b/packages/client/src/components/ConnectionModal.tsx
@@ -41,7 +41,7 @@ interface ConnectionModalProps {
 interface TunnelDef { id: string; localPort: string; remoteHost: string; remotePort: string; }
 
 /** Common remote desktop scaling (Windows / macOS / GNOME / KDE). */
-const VNC_DESKTOP_SCALES = [100, 125, 150, 175, 200, 225, 250, 300] as const;
+const VNC_DESKTOP_SCALES = [100, 125, 150, 165, 175, 200, 225, 250, 300] as const;
 
 function nearestVncDesktopScale(factor: number): string {
   if (!Number.isFinite(factor) || factor <= 0 || factor === 1) return '100';

--- a/packages/client/src/components/ConnectionModal.tsx
+++ b/packages/client/src/components/ConnectionModal.tsx
@@ -26,6 +26,10 @@ export interface ConnectionPrefill {
   smbShare: string;
   smbDomain: string;
   tunnels: TunnelDef[];
+  pointerScaleX?: string;
+  pointerScaleY?: string;
+  pointerOffsetX?: string;
+  pointerOffsetY?: string;
 }
 
 interface ConnectionModalProps {
@@ -197,6 +201,10 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
   const [tunnels, setTunnels] = useState<TunnelDef[]>(prefill?.tunnels ?? []);
   const [smbShare, setSmbShare] = useState(prefill?.smbShare ?? '');
   const [smbDomain, setSmbDomain] = useState(prefill?.smbDomain ?? '');
+  const [vncScaleX, setVncScaleX] = useState(prefill?.pointerScaleX ?? '');
+  const [vncScaleY, setVncScaleY] = useState(prefill?.pointerScaleY ?? '');
+  const [vncOffX, setVncOffX] = useState(prefill?.pointerOffsetX ?? '');
+  const [vncOffY, setVncOffY] = useState(prefill?.pointerOffsetY ?? '');
   // DB-specific fields
   const [dbDatabase, setDbDatabase] = useState('');
   const [dbSslMode, setDbSslMode] = useState<'disable' | 'require' | 'verify-ca' | 'verify-full'>('disable');
@@ -237,6 +245,10 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         if (d.tags && Array.isArray(d.tags)) setTags(d.tags);
         if (d.skipCertValidation !== undefined) setSkipCertValidation(!!d.skipCertValidation);
         if (d.extraConfig?.promptOnConnect) setPromptOnConnect(true);
+        if (d.extraConfig?.pointerScaleX != null && d.extraConfig.pointerScaleX !== 1) setVncScaleX(String(d.extraConfig.pointerScaleX));
+        if (d.extraConfig?.pointerScaleY != null && d.extraConfig.pointerScaleY !== 1) setVncScaleY(String(d.extraConfig.pointerScaleY));
+        if (d.extraConfig?.pointerOffsetX) setVncOffX(String(d.extraConfig.pointerOffsetX));
+        if (d.extraConfig?.pointerOffsetY) setVncOffY(String(d.extraConfig.pointerOffsetY));
         if (d.shares && Array.isArray(d.shares)) {
           setSelectedShareRoles(d.shares.filter((s: { shareType: string }) => s.shareType === 'role').map((s: { targetId: string }) => s.targetId));
           setSelectedShareUsers(d.shares.filter((s: { shareType: string }) => s.shareType === 'user').map((s: { targetId: string }) => s.targetId));
@@ -320,6 +332,23 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         if (dbQueryTimeout.trim()) dbCfg.queryTimeout = parseInt(dbQueryTimeout, 10);
         if (dbIdleTimeout.trim()) dbCfg.idleTimeoutMinutes = parseInt(dbIdleTimeout, 10);
         body.extraConfig = dbCfg;
+      }
+      if (protocol === 'vnc') {
+        const vncCfg: Record<string, number> = {};
+        const sx = vncScaleX.trim() === '' ? 1 : Number(vncScaleX);
+        const sy = vncScaleY.trim() === '' ? 1 : Number(vncScaleY);
+        const ox = vncOffX.trim() === '' ? 0 : Number(vncOffX);
+        const oy = vncOffY.trim() === '' ? 0 : Number(vncOffY);
+        if (![sx, sy, ox, oy].every((n) => Number.isFinite(n))) {
+          setError('VNC pointer scale/offset must be numbers');
+          setSaving(false);
+          return;
+        }
+        if (sx !== 1) vncCfg.pointerScaleX = sx;
+        if (sy !== 1) vncCfg.pointerScaleY = sy;
+        if (ox !== 0) vncCfg.pointerOffsetX = ox;
+        if (oy !== 0) vncCfg.pointerOffsetY = oy;
+        body.extraConfig = Object.keys(vncCfg).length ? vncCfg : null;
       }
       if (protocol === 'rdp') {
         body.skipCertValidation = skipCertValidation;
@@ -696,6 +725,64 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
                   placeholder="WORKGROUP"
                   className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
                 />
+              </div>
+            </div>
+          )}
+
+          {protocol === 'vnc' && (
+            <div className="space-y-2">
+              <div>
+                <label className="block text-xs font-medium text-text-secondary mb-1">Pointer mapping</label>
+                <p className="text-[11px] text-text-secondary mb-1.5 leading-tight">
+                  Leave blank unless the remote cursor sits off the VNC picture (HiDPI / fractional desktop scale).
+                  Sent as <span className="font-mono">x × scaleX + offsetX</span>. Example: scale 0.606 for a 4K capture of a 1.65-scaled desktop.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <div className="flex-1">
+                  <label className="block text-[11px] text-text-secondary mb-1">Scale X</label>
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={vncScaleX}
+                    onChange={(e) => setVncScaleX(e.target.value)}
+                    placeholder="1"
+                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-[11px] text-text-secondary mb-1">Scale Y</label>
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={vncScaleY}
+                    onChange={(e) => setVncScaleY(e.target.value)}
+                    placeholder="1"
+                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-[11px] text-text-secondary mb-1">Offset X</label>
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={vncOffX}
+                    onChange={(e) => setVncOffX(e.target.value)}
+                    placeholder="0"
+                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-[11px] text-text-secondary mb-1">Offset Y</label>
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={vncOffY}
+                    onChange={(e) => setVncOffY(e.target.value)}
+                    placeholder="0"
+                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
+                  />
+                </div>
               </div>
             </div>
           )}

--- a/packages/client/src/components/ConnectionModal.tsx
+++ b/packages/client/src/components/ConnectionModal.tsx
@@ -26,10 +26,7 @@ export interface ConnectionPrefill {
   smbShare: string;
   smbDomain: string;
   tunnels: TunnelDef[];
-  pointerScaleX?: string;
-  pointerScaleY?: string;
-  pointerOffsetX?: string;
-  pointerOffsetY?: string;
+  vncDesktopScale?: string;
 }
 
 interface ConnectionModalProps {
@@ -42,6 +39,24 @@ interface ConnectionModalProps {
 }
 
 interface TunnelDef { id: string; localPort: string; remoteHost: string; remotePort: string; }
+
+/** Common remote desktop scaling (Windows / macOS / GNOME / KDE). */
+const VNC_DESKTOP_SCALES = [100, 125, 150, 175, 200, 225, 250, 300] as const;
+
+function nearestVncDesktopScale(factor: number): string {
+  if (!Number.isFinite(factor) || factor <= 0 || factor === 1) return '100';
+  const pct = 100 / factor;
+  let best: (typeof VNC_DESKTOP_SCALES)[number] = 100;
+  let bestDist = Infinity;
+  for (const option of VNC_DESKTOP_SCALES) {
+    const dist = Math.abs(option - pct);
+    if (dist < bestDist) {
+      best = option;
+      bestDist = dist;
+    }
+  }
+  return String(best);
+}
 
 const defaultPorts: Record<string, number> = {
   ssh: 22,
@@ -201,10 +216,7 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
   const [tunnels, setTunnels] = useState<TunnelDef[]>(prefill?.tunnels ?? []);
   const [smbShare, setSmbShare] = useState(prefill?.smbShare ?? '');
   const [smbDomain, setSmbDomain] = useState(prefill?.smbDomain ?? '');
-  const [vncScaleX, setVncScaleX] = useState(prefill?.pointerScaleX ?? '');
-  const [vncScaleY, setVncScaleY] = useState(prefill?.pointerScaleY ?? '');
-  const [vncOffX, setVncOffX] = useState(prefill?.pointerOffsetX ?? '');
-  const [vncOffY, setVncOffY] = useState(prefill?.pointerOffsetY ?? '');
+  const [vncDesktopScale, setVncDesktopScale] = useState(prefill?.vncDesktopScale ?? '100');
   // DB-specific fields
   const [dbDatabase, setDbDatabase] = useState('');
   const [dbSslMode, setDbSslMode] = useState<'disable' | 'require' | 'verify-ca' | 'verify-full'>('disable');
@@ -245,10 +257,9 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         if (d.tags && Array.isArray(d.tags)) setTags(d.tags);
         if (d.skipCertValidation !== undefined) setSkipCertValidation(!!d.skipCertValidation);
         if (d.extraConfig?.promptOnConnect) setPromptOnConnect(true);
-        if (d.extraConfig?.pointerScaleX != null && d.extraConfig.pointerScaleX !== 1) setVncScaleX(String(d.extraConfig.pointerScaleX));
-        if (d.extraConfig?.pointerScaleY != null && d.extraConfig.pointerScaleY !== 1) setVncScaleY(String(d.extraConfig.pointerScaleY));
-        if (d.extraConfig?.pointerOffsetX) setVncOffX(String(d.extraConfig.pointerOffsetX));
-        if (d.extraConfig?.pointerOffsetY) setVncOffY(String(d.extraConfig.pointerOffsetY));
+        {
+          setVncDesktopScale(nearestVncDesktopScale(Number(d.extraConfig?.pointerScaleX ?? 1)));
+        }
         if (d.shares && Array.isArray(d.shares)) {
           setSelectedShareRoles(d.shares.filter((s: { shareType: string }) => s.shareType === 'role').map((s: { targetId: string }) => s.targetId));
           setSelectedShareUsers(d.shares.filter((s: { shareType: string }) => s.shareType === 'user').map((s: { targetId: string }) => s.targetId));
@@ -334,21 +345,13 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
         body.extraConfig = dbCfg;
       }
       if (protocol === 'vnc') {
-        const vncCfg: Record<string, number> = {};
-        const sx = vncScaleX.trim() === '' ? 1 : Number(vncScaleX);
-        const sy = vncScaleY.trim() === '' ? 1 : Number(vncScaleY);
-        const ox = vncOffX.trim() === '' ? 0 : Number(vncOffX);
-        const oy = vncOffY.trim() === '' ? 0 : Number(vncOffY);
-        if (![sx, sy, ox, oy].every((n) => Number.isFinite(n))) {
-          setError('VNC pointer scale/offset must be numbers');
-          setSaving(false);
-          return;
+        const pct = parseInt(vncDesktopScale, 10) || 100;
+        if (pct === 100) {
+          body.extraConfig = null;
+        } else {
+          const factor = 100 / pct;
+          body.extraConfig = { pointerScaleX: factor, pointerScaleY: factor };
         }
-        if (sx !== 1) vncCfg.pointerScaleX = sx;
-        if (sy !== 1) vncCfg.pointerScaleY = sy;
-        if (ox !== 0) vncCfg.pointerOffsetX = ox;
-        if (oy !== 0) vncCfg.pointerOffsetY = oy;
-        body.extraConfig = Object.keys(vncCfg).length ? vncCfg : null;
       }
       if (protocol === 'rdp') {
         body.skipCertValidation = skipCertValidation;
@@ -730,60 +733,22 @@ export function ConnectionModal({ connection, groups, onClose, onSaved, prefill 
           )}
 
           {protocol === 'vnc' && (
-            <div className="space-y-2">
-              <div>
-                <label className="block text-xs font-medium text-text-secondary mb-1">Pointer mapping</label>
-                <p className="text-[11px] text-text-secondary mb-1.5 leading-tight">
-                  Leave blank unless the remote cursor sits off the VNC picture (HiDPI / fractional desktop scale).
-                  Sent as <span className="font-mono">x × scaleX + offsetX</span>. Example: scale 0.606 for a 4K capture of a 1.65-scaled desktop.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <div className="flex-1">
-                  <label className="block text-[11px] text-text-secondary mb-1">Scale X</label>
-                  <input
-                    type="text"
-                    inputMode="decimal"
-                    value={vncScaleX}
-                    onChange={(e) => setVncScaleX(e.target.value)}
-                    placeholder="1"
-                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label className="block text-[11px] text-text-secondary mb-1">Scale Y</label>
-                  <input
-                    type="text"
-                    inputMode="decimal"
-                    value={vncScaleY}
-                    onChange={(e) => setVncScaleY(e.target.value)}
-                    placeholder="1"
-                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label className="block text-[11px] text-text-secondary mb-1">Offset X</label>
-                  <input
-                    type="text"
-                    inputMode="decimal"
-                    value={vncOffX}
-                    onChange={(e) => setVncOffX(e.target.value)}
-                    placeholder="0"
-                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label className="block text-[11px] text-text-secondary mb-1">Offset Y</label>
-                  <input
-                    type="text"
-                    inputMode="decimal"
-                    value={vncOffY}
-                    onChange={(e) => setVncOffY(e.target.value)}
-                    placeholder="0"
-                    className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent font-mono"
-                  />
-                </div>
-              </div>
+            <div>
+              <label className="block text-xs font-medium text-text-secondary mb-1">Remote display scale</label>
+              <select
+                value={vncDesktopScale}
+                onChange={(e) => setVncDesktopScale(e.target.value)}
+                className="w-full px-2.5 py-1.5 bg-surface border border-border rounded text-sm text-text-primary focus:outline-hidden focus:ring-2 focus:ring-accent"
+              >
+                {VNC_DESKTOP_SCALES.map((pct) => (
+                  <option key={pct} value={String(pct)}>
+                    {pct === 100 ? '100% (default)' : `${pct}%`}
+                  </option>
+                ))}
+              </select>
+              <p className="text-[11px] text-text-secondary mt-1 leading-tight">
+                Match the scaling set on the remote desktop. Use this if the mouse is not lined up with what you see.
+              </p>
             </div>
           )}
 

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -481,10 +481,13 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
         shared: d.shared === 1,
         smbShare: d.extraConfig?.share ?? '',
         smbDomain: d.extraConfig?.domain ?? '',
-        pointerScaleX: d.extraConfig?.pointerScaleX != null && d.extraConfig.pointerScaleX !== 1 ? String(d.extraConfig.pointerScaleX) : '',
-        pointerScaleY: d.extraConfig?.pointerScaleY != null && d.extraConfig.pointerScaleY !== 1 ? String(d.extraConfig.pointerScaleY) : '',
-        pointerOffsetX: d.extraConfig?.pointerOffsetX ? String(d.extraConfig.pointerOffsetX) : '',
-        pointerOffsetY: d.extraConfig?.pointerOffsetY ? String(d.extraConfig.pointerOffsetY) : '',
+        vncDesktopScale: (() => {
+          const sx = Number(d.extraConfig?.pointerScaleX ?? 1);
+          if (!Number.isFinite(sx) || sx <= 0 || sx === 1) return '100';
+          const pct = 100 / sx;
+          const options = [100, 125, 150, 175, 200, 225, 250, 300];
+          return String(options.reduce((best, n) => Math.abs(n - pct) < Math.abs(best - pct) ? n : best, 100));
+        })(),
         tunnels: (d.tunnels ?? []).map((t: { localPort: number; remoteHost: string; remotePort: number }) => ({
           id: crypto.randomUUID(),
           localPort: String(t.localPort),

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -485,7 +485,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
           const sx = Number(d.extraConfig?.pointerScaleX ?? 1);
           if (!Number.isFinite(sx) || sx <= 0 || sx === 1) return '100';
           const pct = 100 / sx;
-          const options = [100, 125, 150, 175, 200, 225, 250, 300];
+          const options = [100, 125, 150, 165, 175, 200, 225, 250, 300];
           return String(options.reduce((best, n) => Math.abs(n - pct) < Math.abs(best - pct) ? n : best, 100));
         })(),
         tunnels: (d.tunnels ?? []).map((t: { localPort: number; remoteHost: string; remotePort: number }) => ({

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -484,9 +484,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
         vncDesktopScale: (() => {
           const sx = Number(d.extraConfig?.pointerScaleX ?? 1);
           if (!Number.isFinite(sx) || sx <= 0 || sx === 1) return '100';
-          const pct = 100 / sx;
-          const options = [100, 125, 150, 165, 175, 200, 225, 250, 300];
-          return String(options.reduce((best, n) => Math.abs(n - pct) < Math.abs(best - pct) ? n : best, 100));
+          return String(Math.round(100 / sx));
         })(),
         tunnels: (d.tunnels ?? []).map((t: { localPort: number; remoteHost: string; remotePort: number }) => ({
           id: crypto.randomUUID(),

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -481,6 +481,10 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
         shared: d.shared === 1,
         smbShare: d.extraConfig?.share ?? '',
         smbDomain: d.extraConfig?.domain ?? '',
+        pointerScaleX: d.extraConfig?.pointerScaleX != null && d.extraConfig.pointerScaleX !== 1 ? String(d.extraConfig.pointerScaleX) : '',
+        pointerScaleY: d.extraConfig?.pointerScaleY != null && d.extraConfig.pointerScaleY !== 1 ? String(d.extraConfig.pointerScaleY) : '',
+        pointerOffsetX: d.extraConfig?.pointerOffsetX ? String(d.extraConfig.pointerOffsetX) : '',
+        pointerOffsetY: d.extraConfig?.pointerOffsetY ? String(d.extraConfig.pointerOffsetY) : '',
         tunnels: (d.tunnels ?? []).map((t: { localPort: number; remoteHost: string; remotePort: number }) => ({
           id: crypto.randomUUID(),
           localPort: String(t.localPort),

--- a/packages/client/src/components/VncSession.tsx
+++ b/packages/client/src/components/VncSession.tsx
@@ -4,6 +4,7 @@ import { getWsTicket } from '../lib/wsTicket';
 import { DisconnectOverlay } from './DisconnectOverlay';
 import { VncControlPanel } from './VncControlPanel';
 import { VncMobileKeyboard } from './VncMobileKeyboard';
+import { applyVncPointerMap } from '../lib/vncPointerMap';
 
 interface VncSessionProps {
   connectionId: string;
@@ -57,7 +58,7 @@ export function VncSession({ connectionId, connectionName, isActive, onStatusCha
           credentials: 'include',
         });
         if (!res.ok) throw new Error('Failed to fetch connection credentials');
-        const info: { username?: string; password?: string } = await res.json();
+        const info: { username?: string; password?: string; extraConfig?: unknown } = await res.json();
         if (cancelled) return;
 
         // noVNC 1.7.0 ships as pure ESM so a direct dynamic import works
@@ -128,6 +129,7 @@ export function VncSession({ connectionId, connectionName, isActive, onStatusCha
         resizeObserver.observe(container);
 
         rfb.addEventListener('connect', () => {
+          if (rfb) applyVncPointerMap(rfb, info.extraConfig);
           if (!cancelled) setAndNotify('connected');
         });
 

--- a/packages/client/src/lib/vncPointerMap.ts
+++ b/packages/client/src/lib/vncPointerMap.ts
@@ -1,0 +1,69 @@
+/** Optional per-connection VNC pointer mapping.
+
+When a VNC server advertises physical framebuffer pixels but the remote
+desktop's pointer lives in a different (often logical / HiDPI-scaled)
+coordinate space, clicks land in the wrong place. These values remap
+noVNC's framebuffer coordinates before they are sent:
+
+  remoteX = round(vncX * pointerScaleX + pointerOffsetX)
+  remoteY = round(vncY * pointerScaleY + pointerOffsetY)
+
+Defaults (1, 1, 0, 0) are a no-op and must stay that way so ordinary
+VNC hosts are unchanged.
+*/
+export type VncPointerMap = {
+  pointerScaleX: number;
+  pointerScaleY: number;
+  pointerOffsetX: number;
+  pointerOffsetY: number;
+};
+
+function num(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+export function parseVncPointerMap(extra: unknown): VncPointerMap {
+  const o = extra && typeof extra === 'object' ? (extra as Record<string, unknown>) : {};
+  return {
+    pointerScaleX: num(o.pointerScaleX, 1),
+    pointerScaleY: num(o.pointerScaleY, 1),
+    pointerOffsetX: num(o.pointerOffsetX, 0),
+    pointerOffsetY: num(o.pointerOffsetY, 0),
+  };
+}
+
+export function isIdentityPointerMap(map: VncPointerMap): boolean {
+  return (
+    map.pointerScaleX === 1 &&
+    map.pointerScaleY === 1 &&
+    map.pointerOffsetX === 0 &&
+    map.pointerOffsetY === 0
+  );
+}
+
+type RfbDisplay = {
+  __gatwyPtrMap?: boolean;
+  _display?: {
+    absX: (n: number) => number;
+    absY: (n: number) => number;
+  };
+};
+
+/** Wrap noVNC Display.absX/absY. Safe to call more than once. */
+export function applyVncPointerMap(rfb: object, extra: unknown): boolean {
+  const map = parseVncPointerMap(extra);
+  if (isIdentityPointerMap(map)) return false;
+  const rec = rfb as RfbDisplay;
+  if (rec.__gatwyPtrMap || !rec._display) return false;
+  const ax = rec._display.absX.bind(rec._display);
+  const ay = rec._display.absY.bind(rec._display);
+  rec._display.absX = (n) => Math.round(ax(n) * map.pointerScaleX + map.pointerOffsetX);
+  rec._display.absY = (n) => Math.round(ay(n) * map.pointerScaleY + map.pointerOffsetY);
+  rec.__gatwyPtrMap = true;
+  return true;
+}

--- a/packages/client/src/lib/vncPointerMap.ts
+++ b/packages/client/src/lib/vncPointerMap.ts
@@ -1,15 +1,9 @@
-/** Optional per-connection VNC pointer mapping.
+/** Optional per-connection VNC pointer scale.
 
-When a VNC server advertises physical framebuffer pixels but the remote
-desktop's pointer lives in a different (often logical / HiDPI-scaled)
-coordinate space, clicks land in the wrong place. These values remap
-noVNC's framebuffer coordinates before they are sent:
-
-  remoteX = round(vncX * pointerScaleX + pointerOffsetX)
-  remoteY = round(vncY * pointerScaleY + pointerOffsetY)
-
-Defaults (1, 1, 0, 0) are a no-op and must stay that way so ordinary
-VNC hosts are unchanged.
+If the remote desktop is scaled (125%, 150%, 200%, …) but VNC still
+sends the full-resolution picture, the cursor can sit in the wrong place.
+Set pointerScaleX/Y to 100 / desktopScalePercent. Leave at 1 for a
+normal (100%) desktop.
 */
 export type VncPointerMap = {
   pointerScaleX: number;

--- a/packages/client/src/types/novnc.d.ts
+++ b/packages/client/src/types/novnc.d.ts
@@ -36,6 +36,11 @@ declare module '@novnc/novnc' {
     qualityLevel: number;
     compressionLevel: number;
     focusOnClick: boolean;
+    /** Internal noVNC Display; used to remap pointer coords. */
+    _display?: {
+      absX: (n: number) => number;
+      absY: (n: number) => number;
+    };
 
     disconnect(): void;
     sendCredentials(creds: { username?: string; password?: string; target?: string }): void;

--- a/packages/server/src/routes/connections.ts
+++ b/packages/server/src/routes/connections.ts
@@ -536,11 +536,15 @@ router.get('/:id/session', (req: Request, res: Response) => {
 
   const password = conn.encrypted_password ? decrypt(conn.encrypted_password) : '';
 
+  let extraConfig: unknown = null;
+  try { if (conn.extra_config_json) extraConfig = JSON.parse(conn.extra_config_json); } catch { /* ignore */ }
+
   res.json({
     host: conn.host,
     port: conn.port,
     username: conn.username || '',
     password,
+    extraConfig,
   });
 });
 


### PR DESCRIPTION
## Why                                                                                                                                                                                              
                                                                                                                                                                                                       
   Some VNC servers send a full-resolution picture while the remote desktop itself is scaled (125%, 150%, 200%, etc.). The picture looks fine, but the mouse sits in the wrong place because the click coordinates still use the unscaled framebuffer.                                                                                                                                                       
                                                                                                                                                                                                       
   This showed up on a HiDPI / fractionally scaled Linux desktop. It is not specific to one OS.                                                                                                        
                                                                                                                                                                                                       
   ## What this does                                                                                                                                                                                   
                                                                                                                                                                                                       
   Adds an optional **Remote display scale** field on the VNC connection form.                                                                                                                         
                                                                                                                                                                                                       
   - Default is **100%** — existing connections are unchanged                                                                                                                                          
   - Common presets: 125%, 150%, 175%, 200%, 225%, 250%, 300%                                                                                                                                          
   - **Custom** for anything else (for example 165%)                                                                                                                                                   
                                                                                                                                                                                                       
   Pick the same scale the remote desktop uses. Gatwy then maps pointer coordinates before they are sent.                                                                                              
                                                                                                                                                                                                       
   ## How it works                                                                                                                                                                                     
                                                                                                                                                                                                       
   The value is stored in the connection’s existing `extraConfig` as `pointerScaleX` / `pointerScaleY`. The session API already returns other extraConfig for SSH/SMB/DB; it now returns it for VNC as well so the viewer can apply the map on connect.                                                                                        
                                                                                                                                                                                                       
   ## What this is not                                                                                                                                                                                 
                                                                                                                                                                                                       
   - It does not change how the picture is scaled in the browser (“Scale to fit” is unchanged)                                                                                                         
   - It does not affect RDP, SSH, or other protocols                                                                                                                                                   
   - It does not run unless the user sets a scale other than 100%                                                                                                                                      
                                                                                                                                                                                                      