### PR TITLE
feat(sidebar): always show connection tree actions on mobile + mobile QoL

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -2,9 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#141414" media="(prefers-color-scheme: dark)" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="Gatwy" />
     <title>Gatwy</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Inconsolata:wght@400;500&family=Roboto+Mono:wght@400;500&family=Source+Code+Pro:wght@400;500&family=Ubuntu+Mono&display=swap" rel="stylesheet" />

--- a/packages/client/public/manifest.webmanifest
+++ b/packages/client/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Gatwy",
+  "short_name": "Gatwy",
+  "description": "Browser-based remote access",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#141414",
+  "theme_color": "#3b82f6",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/packages/client/src/components/Header.tsx
+++ b/packages/client/src/components/Header.tsx
@@ -100,7 +100,7 @@ export function Header({
 
   return (
     <>
-    <header className="flex items-center justify-between h-12 px-4 bg-surface-alt border-b border-border shrink-0">
+    <header className="sticky top-0 z-40 flex items-center justify-between h-[calc(3rem+env(safe-area-inset-top,0px))] pt-[env(safe-area-inset-top,0px)] px-4 bg-surface-alt border-b border-border shrink-0">
       <div className="flex items-center gap-3">
         <button
           onClick={onCycleSidebarMode}
@@ -108,9 +108,9 @@ export function Header({
           onMouseLeave={onSidebarButtonHoverEnd}
           className={`p-1.5 rounded hover:bg-surface-hover transition-colors ${
             sidebarMode === 'open'
-              ? 'text-accent bg-accent/10'
+              ? 'text-accent bg-surface-hover'
               : sidebarMode === 'hide'
-              ? 'text-accent/70 bg-accent/5'
+              ? 'text-accent bg-surface-hover'
               : 'text-text-secondary'
           }`}
           title={`Sidebar: ${sidebarMode} — click to cycle (Ctrl+\`)`}
@@ -225,7 +225,7 @@ export function Header({
             href={releaseUrl}
             target="_blank"
             rel="noreferrer"
-            className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-xs font-medium hover:bg-accent/25 transition-colors"
+            className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent text-white text-xs font-medium hover:bg-accent-hover transition-colors"
             title={`New version available: v${latest}`}
           >
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
@@ -234,7 +234,7 @@ export function Header({
             v{latest} available
           </a>
         ) : upToDate && !checking ? (
-          <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/15 text-green-400 text-xs font-medium">
+          <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-600 text-white text-xs font-medium">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
               <polyline points="20 6 9 17 4 12" />
             </svg>

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as RMouseEvent } from 'react';
 import { clsx } from 'clsx';
 import { useSettings } from '../hooks/useSettings';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { ConnectionModal, type ConnectionPrefill } from './ConnectionModal';
 import { type Protocol } from '../types/protocol.js';
 import { pointerScaleToPercent } from '../lib/vncPointerMap';
@@ -46,6 +47,10 @@ interface FolderContextMenu {
   y: number;
   group: ConnectionGroup;
 }
+
+type DeleteFolderConfirm =
+  | { kind: 'group'; group: ConnectionGroup; connCount: number }
+  | { kind: 'connection'; conn: Connection };
 
 function flattenGroups(groups: ConnectionGroup[], prefix = ''): FlatGroup[] {
   const result: FlatGroup[] = [];
@@ -207,6 +212,7 @@ function ProtocolSubmenuItems({ groupId: _groupId, onSelect }: { groupId: string
 
 export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
   const { settings } = useSettings();
+  const isMobile = useIsMobile();
   const healthMonitorEnabled = settings['health_monitor.enabled'] !== 'false';
   const [groups, setGroups] = useState<ConnectionGroup[]>([]);
   const [ungrouped, setUngrouped] = useState<Connection[]>([]);
@@ -241,7 +247,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
   const [renameValue, setRenameValue] = useState('');
   const [newConnGroupId, setNewConnGroupId] = useState<string | null>(null);
   const [newConnProtocol, setNewConnProtocol] = useState<Protocol>('rdp');
-  const [deleteFolderConfirm, setDeleteFolderConfirm] = useState<{ group: ConnectionGroup; connCount: number } | null>(null);
+  const [deleteFolderConfirm, setDeleteFolderConfirm] = useState<DeleteFolderConfirm | null>(null);
   const [showExportConfirm, setShowExportConfirm] = useState(false);
   const [importResult, setImportResult] = useState<{ connectionsCreated: number; groupsCreated: number } | { error: string } | null>(null);
   const [showSearch, setShowSearch] = useState(false);
@@ -394,7 +400,16 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
       method: 'DELETE',
       credentials: 'include',
     });
+    setDeleteFolderConfirm(null);
     fetchConnections();
+  }
+
+  function requestDeleteConnection(conn: Connection) {
+    if (isMobile) {
+      setDeleteFolderConfirm({ kind: 'connection', conn });
+      return;
+    }
+    void deleteConnection(conn.id);
   }
 
   function requestDeleteGroup(group: ConnectionGroup) {
@@ -402,8 +417,10 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
     const count = (g: ConnectionGroup): number =>
       g.connections.length + g.children.reduce((s, c) => s + count(c), 0);
     const connCount = count(group);
-    if (connCount > 0) {
-      setDeleteFolderConfirm({ group, connCount });
+    // Hover/fine pointer: only folders with connections confirm.
+    // Coarse/no-hover: always confirm, including empty folders, because trash is always visible.
+    if (connCount > 0 || isMobile) {
+      setDeleteFolderConfirm({ kind: 'group', group, connCount });
     } else {
       void confirmDeleteGroup(group.id);
     }
@@ -416,6 +433,15 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
     });
     setDeleteFolderConfirm(null);
     fetchConnections();
+  }
+
+  function confirmPendingDelete() {
+    if (!deleteFolderConfirm) return;
+    if (deleteFolderConfirm.kind === 'connection') {
+      void deleteConnection(deleteFolderConfirm.conn.id);
+      return;
+    }
+    void confirmDeleteGroup(deleteFolderConfirm.group.id);
   }
 
   async function renameGroup(id: string, newName: string) {
@@ -822,7 +848,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
             {conn.tags.length > 2 && <span className="text-[9px] text-text-secondary">+{conn.tags.length - 2}</span>}
           </span>
         )}
-        <div className="hidden group-hover/conn:flex items-center gap-0.5 shrink-0">
+        <div className={isMobile ? 'flex items-center gap-0.5 shrink-0' : 'hidden group-hover/conn:flex items-center gap-0.5 shrink-0'}>
           <button
             onClick={(e) => { e.stopPropagation(); setEditingConnection(conn); setShowModal(true); }}
             title="Edit"
@@ -831,7 +857,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
             <EditIcon />
           </button>
           <button
-            onClick={(e) => { e.stopPropagation(); deleteConnection(conn.id); }}
+            onClick={(e) => { e.stopPropagation(); requestDeleteConnection(conn); }}
             title="Delete"
             className="p-1 rounded text-text-secondary hover:text-red-400 hover:bg-surface"
           >
@@ -1005,7 +1031,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
           <button
             onClick={(e) => { e.stopPropagation(); requestDeleteGroup(group); }}
             title="Delete folder"
-            className="hidden group-hover/folder:flex p-1 rounded text-text-secondary hover:text-red-400 hover:bg-surface"
+            className={isMobile ? 'flex p-1 rounded text-text-secondary hover:text-red-400 hover:bg-surface' : 'hidden group-hover/folder:flex p-1 rounded text-text-secondary hover:text-red-400 hover:bg-surface'}
           >
             <TrashIcon size={11} />
           </button>
@@ -1419,12 +1445,20 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
                 <TrashIcon size={16} />
               </div>
               <div>
-                <h3 className="text-sm font-semibold text-text-primary mb-1">Delete "{deleteFolderConfirm.group.name}"?</h3>
-                <p className="text-xs text-text-secondary leading-relaxed">
-                  This folder contains <span className="font-semibold text-red-400">{deleteFolderConfirm.connCount} connection{deleteFolderConfirm.connCount !== 1 ? 's' : ''}</span>.
-                  Deleting this folder will permanently remove all connections inside it.
-                  This action cannot be undone.
-                </p>
+                <h3 className="text-sm font-semibold text-text-primary mb-1">
+                  Delete "{deleteFolderConfirm.kind === 'connection' ? deleteFolderConfirm.conn.name : deleteFolderConfirm.group.name}"?
+                </h3>
+                {deleteFolderConfirm.kind === 'group' && deleteFolderConfirm.connCount > 0 ? (
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    This folder contains <span className="font-semibold text-red-400">{deleteFolderConfirm.connCount} connection{deleteFolderConfirm.connCount !== 1 ? 's' : ''}</span>.
+                    Deleting this folder will permanently remove all connections inside it.
+                    This action cannot be undone.
+                  </p>
+                ) : (
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    This action cannot be undone.
+                  </p>
+                )}
               </div>
             </div>
             <div className="flex gap-2 justify-end">
@@ -1437,10 +1471,12 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
               </button>
               <button
                 type="button"
-                onClick={() => confirmDeleteGroup(deleteFolderConfirm.group.id)}
+                onClick={confirmPendingDelete}
                 className="px-3 py-1.5 text-xs bg-red-500 hover:bg-red-600 text-white rounded font-medium"
               >
-                Delete folder &amp; {deleteFolderConfirm.connCount} connection{deleteFolderConfirm.connCount !== 1 ? 's' : ''}
+                {deleteFolderConfirm.kind === 'group' && deleteFolderConfirm.connCount > 0
+                  ? `Delete folder & ${deleteFolderConfirm.connCount} connection${deleteFolderConfirm.connCount !== 1 ? 's' : ''}`
+                  : 'Delete'}
               </button>
             </div>
           </div>
@@ -1501,7 +1537,7 @@ export function Sidebar({ onConnect, onConnectMultiple, width }: SidebarProps) {
               </button>
               <button
                 className="w-full px-4 py-1.5 text-left hover:bg-surface-hover text-red-400 flex items-center gap-2"
-                onClick={() => { deleteConnection(contextMenu.conn.id); setContextMenu(null); }}
+                onClick={() => { requestDeleteConnection(contextMenu.conn); setContextMenu(null); }}
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <polyline points="3 6 5 6 21 6" />

--- a/packages/client/src/hooks/useIsMobile.ts
+++ b/packages/client/src/hooks/useIsMobile.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+const COARSE_NO_HOVER = '(hover: none) and (pointer: coarse)';
+
+/**
+ * True when the primary pointer cannot hover and is coarse (finger/stylus).
+ *
+ * That is the same gap as hover-only tree actions: no hover, so Edit/Delete
+ * must stay visible. A mouse (including one plugged into an iPad) reports
+ * hover + fine pointer, so the tree goes back to hover-reveal.
+ *
+ * Not userAgent, not platform, not maxTouchPoints alone (Windows laptops
+ * can report touch without being a coarse-primary device).
+ */
+function readCoarseNoHover(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia(COARSE_NO_HOVER).matches;
+}
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(readCoarseNoHover);
+
+  useEffect(() => {
+    const mql = window.matchMedia(COARSE_NO_HOVER);
+    const onChange = () => setIsMobile(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/packages/client/src/hooks/useTheme.tsx
+++ b/packages/client/src/hooks/useTheme.tsx
@@ -21,6 +21,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
     localStorage.setItem('gatwy-theme', theme);
+    const color = theme === 'dark' ? '#141414' : '#ffffff';
+    document.querySelectorAll('meta[name="theme-color"]').forEach((el) => {
+      el.setAttribute('content', color);
+      el.removeAttribute('media');
+    });
+    const statusBar = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
+    if (statusBar) statusBar.setAttribute('content', theme === 'dark' ? 'black' : 'default');
   }, [theme]);
 
   const toggleTheme = useCallback(() => {

--- a/packages/client/src/pages/MainLayout.tsx
+++ b/packages/client/src/pages/MainLayout.tsx
@@ -671,7 +671,7 @@ export function MainLayout() {
   );
 
   return (
-    <div className="flex flex-col h-screen bg-surface select-none">
+    <div className="flex flex-col h-dvh overflow-hidden overscroll-none bg-surface select-none">
       <IdleMonitor />
       <Header
         sidebarMode={sidebarMode}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -35,6 +35,13 @@
   --accent-hover: #60a5fa;
 }
 
+html, body, #root {
+  height: 100dvh;
+  overflow: hidden;
+  overscroll-behavior: none;
+  background-color: var(--surface);
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
Tree Edit/Delete stay visible when `hover: none` and `pointer: coarse` (mobile).
A mouse, including one plugged into an iPad, goes back to hover-reveal.

On that same mobile signal, Delete uses the existing confirm dialog.

Viewport locks pinch-zoom. PWA uses favicon.png.
The header is sticky with a solid surface-alt fill below safe-area-inset-top. 