### PR TITLE
fix(moonlight): Alpine musl runtime, hostname RTSP, Gatwy stream chrome

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -10,12 +10,15 @@ Gatwy is MIT-licensed. See [LICENSE](LICENSE).
 - It is **not** vendored in this repository.
 - `scripts/fetch-moonlight-web.sh` downloads a **pinned** GitHub release and verifies a baked-in SHA-256. A mismatch or unknown target exits non-zero.
 
-Pinned release: **v2.10.0**
+Pinned release: **v3.0.0-prerelease.5**
+
+Alpine (musl) images fetch the musl assets so the binary can run in-process. glibc hosts fetch the gnu assets.
 
 | Asset | SHA-256 |
 | --- | --- |
-| `moonlight-web-x86_64-unknown-linux-gnu.tar.gz` | `b17fa535676a1c118bc1eb009134644cab98190b36a0776fb1b4a505d569f5eb` |
-| `moonlight-web-aarch64-unknown-linux-gnu.tar.gz` | `1a6bb6845756883671a5a783c0797367e84166c8210f8cfa51059f434f0e5a3a` |
-| `moonlight-web-aarch64-unknown-linux-musl.tar.gz` | `f008a5bfee1e22386564d28308bf00bdde0b33732de74a56858bc013942d2bb0` |
+| `moonlight-web-x86_64-unknown-linux-musl.tar.gz` | `bda8c825db233a50e2500d5bcfd93267ce4d2adc774bd964f325967133ba5b62` |
+| `moonlight-web-x86_64-unknown-linux-gnu.tar.gz` | `a8371ae6c614d672737cf2fa7dfb61fd46627a45f5c4187480e258e4489327c2` |
+| `moonlight-web-aarch64-unknown-linux-gnu.tar.gz` | `eab9866eec4991db5884d95886cc4f3bec9695fa9e9e052cc64f19b6a72a7226` |
+| `moonlight-web-aarch64-unknown-linux-musl.tar.gz` | `3f5bb7f1b44f16beaf06f946e7dea29f3cb07834c50e18a5e6a2a1966d1e7023` |
 
 Source and license: https://github.com/MrCreativ3001/moonlight-web-stream

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,18 +12,13 @@ case "$ml_flag" in
   1|true|yes)
     dest="/opt/moonlight-web"
     mkdir -p "$dest"
-    # Official x86_64 moonlight-web builds are glibc. gcompat is best-effort on Alpine.
-    if [ -f /etc/alpine-release ]; then
-      echo "[Gatwy] ENABLE_MOONLIGHT set; installing gcompat for glibc moonlight-web binaries"
-      apk add --no-cache gcompat || echo "[Gatwy] WARNING: apk add gcompat failed — moonlight-web may fail to start. Ensure outbound network access is available during container startup, or use a glibc-based host OS."
-    fi
-    if [ ! -x "$dest/web-server" ] || [ ! -x "$dest/streamer" ]; then
+    if [ ! -x "$dest/web-server" ]; then
       echo "[Gatwy] ENABLE_MOONLIGHT=$ENABLE_MOONLIGHT: fetching moonlight-web-stream (GPL-3.0) into $dest"
       fetch-moonlight-web "$dest"
     else
       echo "[Gatwy] ENABLE_MOONLIGHT set; moonlight-web already present at $dest"
     fi
-    chmod +x "$dest/web-server" "$dest/streamer"
+    chmod +x "$dest/web-server"
     chown -R node:node "$dest"
     ;;
 esac

--- a/packages/client/public/moonlight-overlay.css
+++ b/packages/client/public/moonlight-overlay.css
@@ -1,0 +1,247 @@
+/* Overlay for proxied /mlw/stream.html. Dark tokens: the canvas is always black. */
+
+html.stream {
+  --surface: #141414;
+  --surface-alt: #1c1c1c;
+  --surface-hover: #272727;
+  --border: #2e2e2e;
+  --text-primary: #efefef;
+  --text-secondary: #888888;
+  --accent: #3b82f6;
+  --accent-hover: #60a5fa;
+}
+
+html.stream,
+html.stream body.stream {
+  background: #000 !important;
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 13px;
+  text-shadow: none;
+}
+
+html.stream body.stream::before {
+  display: none !important;
+}
+
+/* moonlight-web defaults the HUD to the left and applies sidebar-edge-* after paint. */
+
+html.stream .sidebar-overlay {
+  top: 50% !important;
+  left: auto !important;
+  right: 0 !important;
+  z-index: 40;
+}
+
+html.stream .sidebar-background {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0 !important;
+}
+
+html.stream .sidebar-overlay:not(.sidebar-show) .sidebar-background {
+  transform: translate(calc(100% - 28px), -50%) !important;
+}
+
+html.stream .sidebar-overlay.sidebar-show .sidebar-background {
+  transform: translate(0, -50%) !important;
+}
+
+html.stream .sidebar-button {
+  width: 28px !important;
+  height: auto !important;
+  min-height: 92px;
+  padding: 14px 0 !important;
+  margin: 0 !important;
+  border-radius: 10px 0 0 10px;
+  border: 1px solid rgba(46, 46, 46, 0.9);
+  border-right: none;
+  background: rgba(0, 0, 0, 0.62) !important;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: none !important;
+  color: #9ca3af;
+}
+
+html.stream .sidebar-button:hover {
+  background: rgba(0, 0, 0, 0.8) !important;
+  color: #fff;
+}
+
+html.stream .sidebar-button-image {
+  rotate: 0deg !important;
+  filter: invert(1) opacity(0.72);
+  width: 14px !important;
+  height: 14px !important;
+}
+
+html.stream .sidebar-show .sidebar-button-image {
+  transform: rotate(180deg) !important;
+}
+
+html.stream .sidebar-content {
+  background: color-mix(in srgb, var(--surface) 95%, transparent) !important;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--border) !important;
+  border-radius: 12px !important;
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.65);
+  padding: 12px !important;
+  margin: 0 10px 0 0;
+  min-width: 208px;
+  max-width: 240px;
+  color: var(--text-primary);
+}
+
+html.stream .sidebar-stream {
+  gap: 12px;
+}
+
+html.stream .sidebar-stream-buttons {
+  display: flex !important;
+  flex-direction: column;
+  gap: 2px;
+  grid-template-columns: none !important;
+}
+
+html.stream .sidebar-stream-buttons button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px !important;
+  margin: 0 !important;
+  border: none !important;
+  border-radius: 8px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--text-primary) !important;
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: 0;
+  text-shadow: none;
+}
+
+html.stream .sidebar-stream-buttons button:hover {
+  background: var(--surface-hover) !important;
+}
+
+html.stream .sidebar-stream-buttons button:last-child {
+  margin-top: 8px !important;
+  padding-top: 10px !important;
+  border-top: 1px solid var(--border) !important;
+  border-radius: 0 0 8px 8px !important;
+  color: #f87171 !important;
+}
+
+html.stream .sidebar-stream-buttons button:last-child:hover {
+  background: rgba(239, 68, 68, 0.1) !important;
+}
+
+html.stream .sidebar-content .input-div {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+html.stream .sidebar-content label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  text-shadow: none;
+}
+
+html.stream .sidebar-content select,
+html.stream .sidebar-content input:not([type="range"]):not([type="checkbox"]) {
+  width: 100%;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 7px 8px;
+  text-shadow: none;
+  box-shadow: none !important;
+}
+
+html.stream .sidebar-content select:focus,
+html.stream .sidebar-content input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Stats */
+
+html.stream .video-stats {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  color: var(--text-secondary) !important;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.45;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  pointer-events: none;
+}
+
+/* Modals */
+
+html.stream .modal-background {
+  background: rgba(0, 0, 0, 0.7) !important;
+  backdrop-filter: blur(4px);
+}
+
+html.stream .modal-content {
+  background: var(--surface) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 12px !important;
+  box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.55);
+  color: var(--text-primary);
+  width: min(420px, 92vw) !important;
+  margin: 18vh auto !important;
+  padding: 20px !important;
+  text-shadow: none;
+}
+
+html.stream .modal-content button {
+  background: var(--surface-alt) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  color: var(--text-primary) !important;
+  box-shadow: none !important;
+  text-shadow: none;
+  padding: 8px 12px !important;
+}
+
+html.stream .modal-content button:hover {
+  background: var(--surface-hover) !important;
+}
+
+html.stream .notification-element {
+  background: var(--surface) !important;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-primary);
+  text-shadow: none;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+html.stream .context-menu-background {
+  background: var(--surface) !important;
+  border: 1px solid var(--border);
+  border-radius: 10px !important;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+}
+
+html.stream .context-menu-element:hover {
+  background: var(--surface-hover) !important;
+}
+
+html.stream .stream-keyboard-floating-button {
+  border-color: var(--border) !important;
+  background: rgba(20, 20, 20, 0.78) !important;
+  color: var(--text-primary) !important;
+}

--- a/packages/client/src/components/MoonlightSession.tsx
+++ b/packages/client/src/components/MoonlightSession.tsx
@@ -41,14 +41,14 @@ function mapStatus(s: SessionStatus): 'connecting' | 'connected' | 'disconnected
   return 'connecting';
 }
 
-function preferWebsocketTransport(): void {
+/** moonlight-web reads mlSettings from localStorage before painting the HUD. */
+function applyMoonlightChrome(): void {
   try {
     const raw = localStorage.getItem('mlSettings');
     const settings = raw ? JSON.parse(raw) as Record<string, unknown> : {};
-    if (settings.dataTransport !== 'websocket' && settings.dataTransport !== 'webrtc') {
-      settings.dataTransport = 'websocket';
-      localStorage.setItem('mlSettings', JSON.stringify(settings));
-    }
+    settings.dataTransport = 'websocket';
+    settings.sidebarEdge = 'right';
+    localStorage.setItem('mlSettings', JSON.stringify(settings));
   } catch { /* ignore */ }
 }
 
@@ -59,8 +59,6 @@ export function MoonlightSession({
   onStatusChange,
   onClose,
 }: MoonlightSessionProps) {
-  const sessionRef = useRef<HTMLDivElement>(null);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
   const sessionIdRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -69,7 +67,6 @@ export function MoonlightSession({
   const [pin, setPin] = useState<string | null>(null);
   const [showPairModal, setShowPairModal] = useState(false);
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
-  const [appTitle, setAppTitle] = useState('Desktop');
   const [hostLabel, setHostLabel] = useState(connectionName);
   const [bitrate, setBitrate] = useState(20000);
   const [fps, setFps] = useState(60);
@@ -97,28 +94,6 @@ export function MoonlightSession({
     setStreamUrl(null);
     onClose?.();
   }, [auditDisconnect, onClose]);
-
-  const handleFullscreen = useCallback(() => {
-    const el = sessionRef.current;
-    if (!el) return;
-    if (document.fullscreenElement) {
-      void document.exitFullscreen();
-    } else {
-      void el.requestFullscreen().catch(() => undefined);
-    }
-  }, []);
-
-  const forgetPairing = useCallback(async () => {
-    try {
-      await fetch(`/api/v1/moonlight/${connectionId}/pairing`, {
-        method: 'DELETE',
-        credentials: 'include',
-      });
-    } catch { /* ignore */ }
-    setStreamUrl(null);
-    setPin(null);
-    setReconnectCount((n) => n + 1);
-  }, [connectionId]);
 
   const startPairing = useCallback(async (signal: AbortSignal) => {
     setShowPairModal(true);
@@ -168,7 +143,7 @@ export function MoonlightSession({
   }, [connectionId]);
 
   const startStream = useCallback(async (signal: AbortSignal) => {
-    preferWebsocketTransport();
+    applyMoonlightChrome();
     const res = await fetch(`/api/v1/moonlight/${connectionId}/session`, {
       method: 'POST',
       credentials: 'include',
@@ -183,7 +158,6 @@ export function MoonlightSession({
     if (!res.ok) throw new Error(data.error || `Failed to start stream (${res.status})`);
 
     sessionIdRef.current = data.sessionId;
-    setAppTitle(data.appTitle);
     setBitrate(data.bitrateKbps);
     setFps(data.fps);
     setStreamUrl(data.streamPath);
@@ -249,106 +223,45 @@ export function MoonlightSession({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connectionId, isActive, reconnectCount]);
 
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data as { source?: string; type?: string } | null;
+      if (data?.source === 'gatwy-mlw' && data.type === 'exit') {
+        handleDisconnect();
+      }
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [handleDisconnect]);
+
   return (
-    <div ref={sessionRef} className="absolute inset-0 bg-black flex flex-col">
-      <div className="flex items-center gap-2 px-3 py-1.5 bg-surface-alt border-b border-border/40 shrink-0 text-xs text-text-secondary">
-        <span
-          className={`w-2 h-2 rounded-full shrink-0 ${
-            status === 'streaming'
-              ? 'bg-green-500'
-              : status === 'disconnected'
-              ? 'bg-red-500'
-              : 'bg-yellow-500'
-          }`}
+    <div className="absolute inset-0 bg-black overflow-hidden">
+      {streamUrl && status === 'streaming' ? (
+        <iframe
+          title={`Moonlight ${connectionName}`}
+          src={streamUrl}
+          className="absolute inset-0 w-full h-full border-0"
+          allow="fullscreen; autoplay; clipboard-read; clipboard-write; gamepad"
         />
-        <span className="font-medium text-text-primary">{connectionName}</span>
-        <span className="opacity-50">Moonlight</span>
-        {appTitle && status === 'streaming' && <span className="opacity-50">{appTitle}</span>}
-        {status === 'connecting' && <span className="opacity-50">Connecting…</span>}
-        {status === 'pairing' && <span className="opacity-50">Waiting for PIN…</span>}
-        {status === 'streaming' && (
-          <span className="opacity-50">{Math.round(bitrate / 1000)} Mbps · {fps} fps</span>
-        )}
-        {errorMsg && !showPairModal && <span className="text-red-400 ml-auto truncate max-w-[40%]">{errorMsg}</span>}
-        <div className={`flex items-center gap-1 ${errorMsg && !showPairModal ? '' : 'ml-auto'}`}>
-          <label className="flex items-center gap-1 opacity-70">
-            <span>Mbps</span>
-            <input
-              type="number"
-              min={1}
-              max={150}
-              value={Math.round(bitrate / 1000)}
-              onChange={(e) => setBitrate(Math.max(1, parseInt(e.target.value, 10) || 20) * 1000)}
-              className="w-12 bg-surface border border-border rounded px-1 py-0.5 text-[11px]"
-              title="Bitrate (applies on reconnect)"
-            />
-          </label>
-          <label className="flex items-center gap-1 opacity-70">
-            <span>FPS</span>
-            <input
-              type="number"
-              min={15}
-              max={240}
-              value={fps}
-              onChange={(e) => setFps(Math.max(15, parseInt(e.target.value, 10) || 60))}
-              className="w-12 bg-surface border border-border rounded px-1 py-0.5 text-[11px]"
-              title="FPS (applies on reconnect)"
-            />
-          </label>
-          <button
-            type="button"
-            onClick={handleFullscreen}
-            className="px-2 py-1 rounded border border-border/60 hover:bg-surface"
-            title="Fullscreen"
-          >
-            Fullscreen
-          </button>
-          <button
-            type="button"
-            onClick={() => void forgetPairing()}
-            className="px-2 py-1 rounded border border-border/60 hover:bg-surface"
-            title="Forget pairing and re-pair"
-          >
-            Forget pairing
-          </button>
-          <button
-            type="button"
-            onClick={handleDisconnect}
-            className="px-2 py-1 rounded border border-red-500/40 text-red-400 hover:bg-red-500/10"
-          >
-            Disconnect
-          </button>
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center text-sm text-text-secondary">
+          {status === 'pairing' ? 'Waiting for Sunshine PIN confirmation…' : 'Preparing Moonlight stream…'}
         </div>
-      </div>
+      )}
 
-      <div className="flex-1 relative overflow-hidden bg-black">
-        {streamUrl && status === 'streaming' ? (
-          <iframe
-            ref={iframeRef}
-            title={`Moonlight ${connectionName}`}
-            src={streamUrl}
-            className="absolute inset-0 w-full h-full border-0"
-            allow="fullscreen; autoplay; clipboard-read; clipboard-write; gamepad"
-          />
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-sm text-text-secondary">
-            {status === 'pairing' ? 'Waiting for Sunshine PIN confirmation…' : 'Preparing Moonlight stream…'}
-          </div>
-        )}
-
-        {showPairModal && (
-          <MoonlightPairModal
-            pin={pin}
-            hostLabel={hostLabel}
-            error={status === 'disconnected' ? errorMsg : undefined}
-            onCancel={handleDisconnect}
-            onRetry={() => {
-              setErrorMsg('');
-              setReconnectCount((n) => n + 1);
-            }}
-          />
-        )}
-      </div>
+      {showPairModal && (
+        <MoonlightPairModal
+          pin={pin}
+          hostLabel={hostLabel}
+          error={status === 'disconnected' ? errorMsg : undefined}
+          onCancel={handleDisconnect}
+          onRetry={() => {
+            setErrorMsg('');
+            setReconnectCount((n) => n + 1);
+          }}
+        />
+      )}
 
       <DisconnectOverlay
         show={status === 'disconnected' && !showPairModal}

--- a/packages/server/src/routes/moonlight.ts
+++ b/packages/server/src/routes/moonlight.ts
@@ -5,6 +5,7 @@ import { authRequired } from '../middleware/auth.js';
 import { userHasPermission, wsCanAccess } from '../services/permissions.js';
 import { logAudit } from '../services/audit.js';
 import { resolveClientIp } from '../services/ip.js';
+import { resolveMoonlightHostAddress } from '../services/moonlightAddress.js';
 import {
   ensureMoonlightWeb,
   getMoonlightRuntimeError,
@@ -81,6 +82,7 @@ async function ensureHost(conn: ConnRow, extra: MoonlightExtraConfig): Promise<{
   await ensureMoonlightWeb();
 
   const httpPort = resolveHttpPort(conn.port, extra);
+  const address = await resolveMoonlightHostAddress(conn.host);
   let hostId = extra.mlHostId;
 
   if (hostId) {
@@ -90,19 +92,24 @@ async function ensureHost(conn: ConnRow, extra: MoonlightExtraConfig): Promise<{
     }
     try {
       const host = await mlwGetHost(hostId);
-      return {
-        hostId,
-        extra: mergeMoonlightExtra(extra, {
-          mlHostId: hostId,
-          paired: host.paired === 'Paired',
-        }),
-      };
+      if (host.address === address) {
+        return {
+          hostId,
+          extra: mergeMoonlightExtra(extra, {
+            mlHostId: hostId,
+            paired: host.paired === 'Paired',
+          }),
+        };
+      }
+      // moonlight-common RTSP requires an IP literal; replace hosts stored as DNS names.
+      try { await mlwDeleteHost(hostId); } catch { /* recreate below */ }
+      hostId = undefined;
     } catch {
       hostId = undefined;
     }
   }
 
-  const host = await mlwAddHost(conn.host, httpPort);
+  const host = await mlwAddHost(address, httpPort);
   const next = mergeMoonlightExtra(extra, {
     mlHostId: host.host_id,
     httpPort,

--- a/packages/server/src/services/moonlightAddress.ts
+++ b/packages/server/src/services/moonlightAddress.ts
@@ -1,0 +1,27 @@
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+/**
+ * moonlight-common RTSP setup parses the Sunshine address as an IP literal.
+ * Hostnames pair over HTTP, then fail with "rtsp addr: invalid IP address syntax".
+ */
+export async function resolveMoonlightHostAddress(host: string): Promise<string> {
+  const trimmed = host.trim();
+  if (!trimmed) {
+    throw new Error('Sunshine host is empty');
+  }
+  if (net.isIP(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const { address } = await dns.lookup(trimmed, { family: 4 });
+    return address;
+  } catch {
+    const { address } = await dns.lookup(trimmed);
+    if (!net.isIP(address)) {
+      throw new Error(`Could not resolve Sunshine host ${trimmed} to an IP address`);
+    }
+    return address;
+  }
+}

--- a/packages/server/src/services/moonlightWeb.ts
+++ b/packages/server/src/services/moonlightWeb.ts
@@ -65,7 +65,7 @@ function bindHostPort(): { host: string; port: number } {
   return { host: host || '127.0.0.1', port: parseInt(portStr || '19080', 10) };
 }
 
-function writeConfig(dir: string, binDir: string): string {
+function writeConfig(dir: string): string {
   fs.mkdirSync(dir, { recursive: true });
   const configPath = path.join(dir, 'config.json');
   const { host, port } = bindHostPort();
@@ -90,7 +90,6 @@ function writeConfig(dir: string, binDir: string): string {
       default_http_port: 47989,
       pair_device_name: 'Gatwy',
     },
-    streamer_path: path.join(binDir, 'streamer'),
     webrtc: {
       port_range: { min: WEBRTC_PORT_MIN, max: WEBRTC_PORT_MAX },
       ice_servers: [
@@ -172,8 +171,7 @@ export const MOONLIGHT_UNAVAILABLE_BODY = {
 
 export function moonlightBinariesPresent(dir: string | undefined | null): boolean {
   if (!dir) return false;
-  return fs.existsSync(path.join(dir, 'web-server'))
-    && fs.existsSync(path.join(dir, 'streamer'));
+  return fs.existsSync(path.join(dir, 'web-server'));
 }
 
 export function isMoonlightWebAvailable(): boolean {
@@ -254,16 +252,14 @@ function spawnMoonlightWeb(): Promise<void> {
 
   const binDir = resolveBinaryDir();
   const dir = moonlightDir();
-  const configPath = writeConfig(dir, binDir);
+  const configPath = writeConfig(dir);
   const webServer = path.join(binDir, 'web-server');
-  const streamer = path.join(binDir, 'streamer');
 
   try {
     fs.chmodSync(webServer, 0o755);
-    fs.chmodSync(streamer, 0o755);
   } catch { /* ignore */ }
 
-  console.log(`[Moonlight] Starting web-server from ${binDir} (streamer=${streamer})`);
+  console.log(`[Moonlight] Starting web-server from ${binDir}`);
   const earlyStderr: string[] = [];
   let earlyStderrLen = 0;
   child = spawn(
@@ -273,7 +269,6 @@ function spawnMoonlightWeb(): Promise<void> {
       '--bind-address', DEFAULT_BIND,
       '--path-prefix', PATH_PREFIX,
       '--forwarded-header', MLW_HEADER,
-      '--streamer-path', streamer,
       '--webrtc-port-range', `${WEBRTC_PORT_MIN}:${WEBRTC_PORT_MAX}`,
       'run',
     ],

--- a/packages/server/src/ws/moonlightChrome.ts
+++ b/packages/server/src/ws/moonlightChrome.ts
@@ -1,0 +1,35 @@
+const MARKER = 'data-gatwy-moonlight-chrome';
+
+const HEAD_SNIPPET = `<link rel="stylesheet" href="/moonlight-overlay.css" ${MARKER}>
+<script ${MARKER}>
+(function () {
+  try {
+    var key = 'mlSettings';
+    var settings = JSON.parse(localStorage.getItem(key) || '{}');
+    settings.sidebarEdge = 'right';
+    settings.dataTransport = 'websocket';
+    localStorage.setItem(key, JSON.stringify(settings));
+  } catch (e) {}
+  var originalClose = window.close;
+  // iframe window.close() is a no-op; tell Gatwy to tear down the session.
+  window.close = function () {
+    try { parent.postMessage({ source: 'gatwy-mlw', type: 'exit' }, '*'); } catch (e) {}
+    if (typeof originalClose === 'function') originalClose.call(window);
+  };
+})();
+</script>
+`;
+
+/** Rewrite proxied moonlight-web HTML so the stream HUD uses Gatwy chrome. */
+export function injectGatwyMoonlightChrome(html: string): string {
+  if (html.includes(MARKER)) return html;
+  if (html.includes('</head>')) {
+    return html.replace('</head>', `${HEAD_SNIPPET}</head>`);
+  }
+  return HEAD_SNIPPET + html;
+}
+
+export function shouldThemeMoonlightHtml(urlPath: string): boolean {
+  const path = urlPath.split('?')[0];
+  return path === '/mlw/stream.html' || path.endsWith('/stream.html');
+}

--- a/packages/server/src/ws/moonlightProxy.ts
+++ b/packages/server/src/ws/moonlightProxy.ts
@@ -10,6 +10,7 @@ import {
   moonlightUpstream,
 } from '../services/moonlightWeb.js';
 import { authorizeMoonlightAccess } from './moonlightAuth.js';
+import { injectGatwyMoonlightChrome, shouldThemeMoonlightHtml } from './moonlightChrome.js';
 
 const PREFIX = '/mlw';
 
@@ -103,8 +104,29 @@ export function setupMoonlightProxy(server: Server, app: import('express').Expre
         delete outHeaders['content-security-policy'];
         delete outHeaders['content-security-policy-report-only'];
         outHeaders['content-security-policy'] = MLW_FRAME_CSP;
-        res.writeHead(proxyRes.statusCode ?? 502, outHeaders);
-        proxyRes.pipe(res);
+
+        const contentType = String(proxyRes.headers['content-type'] || '');
+        const encoding = String(proxyRes.headers['content-encoding'] || '');
+        // stream.html only: inject Gatwy HUD CSS/script before moonlight-web JS runs.
+        const themeHtml = shouldThemeMoonlightHtml(targetPath)
+          && contentType.includes('text/html')
+          && (!encoding || encoding === 'identity');
+
+        if (!themeHtml) {
+          res.writeHead(proxyRes.statusCode ?? 502, outHeaders);
+          proxyRes.pipe(res);
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        proxyRes.on('data', (chunk) => chunks.push(chunk));
+        proxyRes.on('end', () => {
+          const html = injectGatwyMoonlightChrome(Buffer.concat(chunks).toString('utf8'));
+          const body = Buffer.from(html, 'utf8');
+          outHeaders['content-length'] = body.length;
+          res.writeHead(proxyRes.statusCode ?? 502, outHeaders);
+          res.end(body);
+        });
       },
     );
 

--- a/packages/server/test/fetchMoonlightWeb.test.ts
+++ b/packages/server/test/fetchMoonlightWeb.test.ts
@@ -12,11 +12,12 @@ const scriptPath = path.resolve(
 describe('scripts/fetch-moonlight-web.sh integrity pin', () => {
   const script = fs.readFileSync(scriptPath, 'utf8');
 
-  it('pins v2.10.0 SHA-256 digests and refuses other versions', () => {
-    assert.match(script, /VERSION="\$\{2:-v2\.10\.0\}"/);
-    assert.match(script, /PINNED_SHA_x86_64_unknown_linux_gnu=b17fa535676a1c118bc1eb009134644cab98190b36a0776fb1b4a505d569f5eb/);
-    assert.match(script, /PINNED_SHA_aarch64_unknown_linux_gnu=1a6bb6845756883671a5a783c0797367e84166c8210f8cfa51059f434f0e5a3a/);
-    assert.match(script, /PINNED_SHA_aarch64_unknown_linux_musl=f008a5bfee1e22386564d28308bf00bdde0b33732de74a56858bc013942d2bb0/);
+  it('pins v3.0.0-prerelease.5 SHA-256 digests and refuses other versions', () => {
+    assert.match(script, /VERSION="\$\{2:-v3\.0\.0-prerelease\.5\}"/);
+    assert.match(script, /PINNED_SHA_x86_64_unknown_linux_musl=bda8c825db233a50e2500d5bcfd93267ce4d2adc774bd964f325967133ba5b62/);
+    assert.match(script, /PINNED_SHA_x86_64_unknown_linux_gnu=a8371ae6c614d672737cf2fa7dfb61fd46627a45f5c4187480e258e4489327c2/);
+    assert.match(script, /PINNED_SHA_aarch64_unknown_linux_gnu=eab9866eec4991db5884d95886cc4f3bec9695fa9e9e052cc64f19b6a72a7226/);
+    assert.match(script, /PINNED_SHA_aarch64_unknown_linux_musl=3f5bb7f1b44f16beaf06f946e7dea29f3cb07834c50e18a5e6a2a1966d1e7023/);
     assert.match(script, /Refusing unpinned moonlight-web-stream version/);
   });
 
@@ -27,5 +28,10 @@ describe('scripts/fetch-moonlight-web.sh integrity pin', () => {
     const mismatchBlock = script.slice(script.indexOf('if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]'));
     assert.match(mismatchBlock, /exit 1/);
     assert.doesNotMatch(script, /IGNORE_CHECKSUM|skip.?checksum|NO_VERIFY/i);
+  });
+
+  it('installs web-server without requiring a separate streamer binary', () => {
+    assert.match(script, /web-server/);
+    assert.doesNotMatch(script, /missing web-server and\/or streamer/);
   });
 });

--- a/packages/server/test/moonlightAddress.test.ts
+++ b/packages/server/test/moonlightAddress.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveMoonlightHostAddress } from '../src/services/moonlightAddress.js';
+
+describe('resolveMoonlightHostAddress', () => {
+  it('returns IPv4 addresses unchanged', async () => {
+    assert.equal(await resolveMoonlightHostAddress('192.0.2.10'), '192.0.2.10');
+    assert.equal(await resolveMoonlightHostAddress(' 198.51.100.20 '), '198.51.100.20');
+  });
+
+  it('returns IPv6 addresses unchanged', async () => {
+    assert.equal(await resolveMoonlightHostAddress('::1'), '::1');
+  });
+
+  it('resolves hostnames to an IP (moonlight RTSP cannot parse DNS names)', async () => {
+    const ip = await resolveMoonlightHostAddress('localhost');
+    assert.match(ip, /^(127\.0\.0\.1|::1)$/);
+  });
+
+  it('rejects an empty host', async () => {
+    await assert.rejects(
+      () => resolveMoonlightHostAddress(''),
+      /empty/i,
+    );
+  });
+});

--- a/packages/server/test/moonlightChrome.test.ts
+++ b/packages/server/test/moonlightChrome.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { injectGatwyMoonlightChrome, shouldThemeMoonlightHtml } from '../src/ws/moonlightChrome.js';
+
+const STREAM_HTML = `<!doctype html><html class="stream"><head><title>Stream</title></head><body class="stream"></body></html>`;
+
+describe('injectGatwyMoonlightChrome', () => {
+  it('loads the Gatwy overlay stylesheet on stream pages', () => {
+    const html = injectGatwyMoonlightChrome(STREAM_HTML);
+    assert.match(html, /href="\/moonlight-overlay\.css"/);
+  });
+
+  it('forces the moonlight-web sidebar onto the right edge before its script runs', () => {
+    const html = injectGatwyMoonlightChrome(STREAM_HTML);
+    assert.match(html, /sidebarEdge/);
+    assert.match(html, /['"]right['"]/);
+  });
+
+  it('is idempotent', () => {
+    const once = injectGatwyMoonlightChrome(STREAM_HTML);
+    const twice = injectGatwyMoonlightChrome(once);
+    assert.equal(once, twice);
+  });
+});
+
+describe('shouldThemeMoonlightHtml', () => {
+  it('themes only the stream document', () => {
+    assert.equal(shouldThemeMoonlightHtml('/mlw/stream.html?hostId=1'), true);
+    assert.equal(shouldThemeMoonlightHtml('/mlw/index.html'), false);
+    assert.equal(shouldThemeMoonlightHtml('/mlw/api/host'), false);
+  });
+});

--- a/packages/server/test/moonlightInProcess.test.ts
+++ b/packages/server/test/moonlightInProcess.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('Moonlight runs inside Gatwy at runtime, not a sidecar', () => {
+  const entrypoint = fs.readFileSync(path.join(root, 'entrypoint.sh'), 'utf8');
+  const dockerfile = fs.readFileSync(path.join(root, 'Dockerfile'), 'utf8');
+  const service = fs.readFileSync(path.join(root, 'packages/server/src/services/moonlightWeb.ts'), 'utf8');
+  const fetchScript = fs.readFileSync(path.join(root, 'scripts/fetch-moonlight-web.sh'), 'utf8');
+  const compose = fs.readFileSync(path.join(root, 'docker-compose.yml'), 'utf8');
+
+  it('entrypoint fetches moonlight-web-stream into /opt/moonlight-web when ENABLE_MOONLIGHT is set', () => {
+    assert.match(entrypoint, /ENABLE_MOONLIGHT/);
+    assert.match(entrypoint, /fetch-moonlight-web/);
+    assert.match(entrypoint, /\/opt\/moonlight-web/);
+    assert.doesNotMatch(entrypoint, /gcompat/);
+  });
+
+  it('Alpine Dockerfile copies the fetch helper and does not add a sidecar image', () => {
+    assert.match(dockerfile, /fetch-moonlight-web/);
+    assert.match(dockerfile, /FROM node:22-alpine/);
+    assert.equal(fs.existsSync(path.join(root, 'Dockerfile.moonlight-web')), false);
+    assert.equal(fs.existsSync(path.join(root, 'scripts/moonlight-web-entrypoint.sh')), false);
+  });
+
+  it('compose has a single gatwy service with no moonlight-web sidecar', () => {
+    assert.doesNotMatch(compose, /moonlight-web:/);
+    assert.doesNotMatch(compose, /Dockerfile\.moonlight-web/);
+    assert.doesNotMatch(compose, /profiles:/);
+  });
+
+  it('server spawns web-server on loopback instead of proxying a sidecar hostname', () => {
+    assert.match(service, /child_process/);
+    assert.match(service, /spawn\(/);
+    assert.match(service, /127\.0\.0\.1:19080/);
+    assert.doesNotMatch(service, /moonlight-web:19080/);
+    assert.doesNotMatch(service, /--streamer-path/);
+  });
+
+  it('fetch helper prefers musl on Alpine including x86_64', () => {
+    assert.match(fetchScript, /x86_64-unknown-linux-musl/);
+    assert.match(fetchScript, /PINNED_SHA_x86_64_unknown_linux_musl=/);
+    assert.match(fetchScript, /v3\.0\.0-prerelease\.5/);
+  });
+});

--- a/packages/server/test/moonlightWeb.test.ts
+++ b/packages/server/test/moonlightWeb.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import {
   moonlightBinariesPresent,
   moonlightUnavailablePayload,
+  moonlightUpstream,
   MOONLIGHT_UNAVAILABLE_BODY,
   MOONLIGHT_MISSING_HINT,
   filterListedConnections,
@@ -20,22 +21,27 @@ describe('moonlightBinariesPresent', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gatwy-mlw-'));
     try {
       assert.equal(moonlightBinariesPresent(dir), false);
-      fs.writeFileSync(path.join(dir, 'web-server'), '');
-      assert.equal(moonlightBinariesPresent(dir), false);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('is true only when web-server and streamer both exist', () => {
+  it('is true when web-server exists (v3 embeds streamer)', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gatwy-mlw-'));
     try {
       fs.writeFileSync(path.join(dir, 'web-server'), '');
-      fs.writeFileSync(path.join(dir, 'streamer'), '');
       assert.equal(moonlightBinariesPresent(dir), true);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('moonlightUpstream', () => {
+  it('points at loopback, not a sidecar hostname', () => {
+    const upstream = moonlightUpstream();
+    assert.equal(upstream.host, '127.0.0.1');
+    assert.equal(upstream.port, 19080);
   });
 });
 
@@ -73,5 +79,6 @@ describe('MOONLIGHT_MISSING_HINT', () => {
     assert.doesNotMatch(MOONLIGHT_MISSING_HINT, /MOONLIGHT_DOWNLOAD/);
     assert.doesNotMatch(MOONLIGHT_MISSING_HINT, /INCLUDE_MOONLIGHT/);
     assert.doesNotMatch(MOONLIGHT_MISSING_HINT, /MOONLIGHT_WEB_DIR/);
+    assert.doesNotMatch(MOONLIGHT_MISSING_HINT, /sidecar/i);
   });
 });

--- a/scripts/fetch-moonlight-web.sh
+++ b/scripts/fetch-moonlight-web.sh
@@ -16,14 +16,15 @@
 set -eu
 
 DEST="${1:-/opt/moonlight-web}"
-VERSION="${2:-v2.10.0}"
+VERSION="${2:-v3.0.0-prerelease.5}"
 ARCH_HINT="${3:-${TARGETARCH:-}}"
 
-# GitHub release asset digests for moonlight-web-stream v2.10.0
-# https://github.com/MrCreativ3001/moonlight-web-stream/releases/tag/v2.10.0
-PINNED_SHA_x86_64_unknown_linux_gnu=b17fa535676a1c118bc1eb009134644cab98190b36a0776fb1b4a505d569f5eb
-PINNED_SHA_aarch64_unknown_linux_gnu=1a6bb6845756883671a5a783c0797367e84166c8210f8cfa51059f434f0e5a3a
-PINNED_SHA_aarch64_unknown_linux_musl=f008a5bfee1e22386564d28308bf00bdde0b33732de74a56858bc013942d2bb0
+# GitHub release asset digests for moonlight-web-stream v3.0.0-prerelease.5
+# https://github.com/MrCreativ3001/moonlight-web-stream/releases/tag/v3.0.0-prerelease.5
+PINNED_SHA_x86_64_unknown_linux_gnu=a8371ae6c614d672737cf2fa7dfb61fd46627a45f5c4187480e258e4489327c2
+PINNED_SHA_x86_64_unknown_linux_musl=bda8c825db233a50e2500d5bcfd93267ce4d2adc774bd964f325967133ba5b62
+PINNED_SHA_aarch64_unknown_linux_gnu=eab9866eec4991db5884d95886cc4f3bec9695fa9e9e052cc64f19b6a72a7226
+PINNED_SHA_aarch64_unknown_linux_musl=3f5bb7f1b44f16beaf06f946e7dea29f3cb07834c50e18a5e6a2a1966d1e7023
 
 echo "moonlight-web-stream is licensed under GPL-3.0."
 echo "Source:  https://github.com/MrCreativ3001/moonlight-web-stream"
@@ -51,9 +52,14 @@ LIBC="$(detect_libc)"
 
 case "$ARCH_HINT" in
   amd64|x86_64)
-    # Upstream does not publish an x86_64 musl tarball for v2.10.0.
-    ML_ARCH=x86_64-unknown-linux-gnu
-    EXPECTED_SHA="$PINNED_SHA_x86_64_unknown_linux_gnu"
+    # gnu x86_64 does not run on Alpine; v3 publishes musl.
+    if [ "$LIBC" = musl ]; then
+      ML_ARCH=x86_64-unknown-linux-musl
+      EXPECTED_SHA="$PINNED_SHA_x86_64_unknown_linux_musl"
+    else
+      ML_ARCH=x86_64-unknown-linux-gnu
+      EXPECTED_SHA="$PINNED_SHA_x86_64_unknown_linux_gnu"
+    fi
     ;;
   arm64|aarch64)
     if [ "$LIBC" = musl ]; then
@@ -70,9 +76,9 @@ case "$ARCH_HINT" in
     ;;
 esac
 
-if [ "$VERSION" != "v2.10.0" ]; then
+if [ "$VERSION" != "v3.0.0-prerelease.5" ]; then
   echo "Refusing unpinned moonlight-web-stream version: $VERSION" >&2
-  echo "This script only installs v2.10.0 with a baked-in SHA-256." >&2
+  echo "This script only installs v3.0.0-prerelease.5 with a baked-in SHA-256." >&2
   exit 1
 fi
 
@@ -126,16 +132,16 @@ if [ ! -f "$EXTRACT/web-server" ] && [ -f "$EXTRACT/package/web-server" ]; then
   EXTRACT="$EXTRACT/package"
 fi
 
-if [ ! -f "$EXTRACT/web-server" ] || [ ! -f "$EXTRACT/streamer" ]; then
-  echo "Release archive is missing web-server and/or streamer" >&2
+if [ ! -f "$EXTRACT/web-server" ]; then
+  echo "Release archive is missing web-server" >&2
   exit 1
 fi
 
-chmod +x "$EXTRACT/web-server" "$EXTRACT/streamer"
+chmod +x "$EXTRACT/web-server"
 
 mkdir -p "$DEST"
 cp -a "$EXTRACT"/. "$DEST"/
-chmod +x "$DEST/web-server" "$DEST/streamer"
+chmod +x "$DEST/web-server"
 
 echo "moonlight-web-stream installed at $DEST"
 echo "Gatwy looks for moonlight-web at /opt/moonlight-web."


### PR DESCRIPTION
## Summary

Fixes the opt-in `ENABLE_MOONLIGHT=1` path on Alpine: the gnu binary never actually started (gcompat is not enough), Sunshine hostnames died at RTSP setup, and the stream HUD still looked like moonlight-web.

Tested end-to-end against Sunshine: pairing, stream start, overlay, disconnect. Still a single container; media stays on the existing HTTPS port.

## What changed

**Runtime**
- Alpine cannot run the official gnu build. Pin moonlight-web-stream **v3.0.0-prerelease.5**, which publishes `x86_64-unknown-linux-musl` and embeds streamer in `web-server`.
- Fetch still happens at container start when `ENABLE_MOONLIGHT=1`. Drop `gcompat` and the separate `streamer` binary check.
- Force WebSocket transport so the stream does not need extra UDP ports.
- In the future, maybe make the release dynamic, defaulting to latest?

**Streaming**
- Resolve Sunshine hostnames to IPv4 before registering the host. moonlight-common parses the RTSP address as an IP literal, so DNS names pair over HTTP and then fail with `rtsp addr: invalid IP address syntax`.

**UI**
- Drop the extra top bar so the session is full-bleed like RDP.
- Pin the moonlight-web HUD to the right edge and restyle it with Gatwy tokens (dark glass tab, stacked flyout, red exit).

## How to test

1. `ENABLE_MOONLIGHT=1 docker compose up --build`
2. Add a Moonlight connection (hostname or IP) and pair in Sunshine.
3. Start a stream: video should appear, overlay tab on the **right**, Gatwy styling.